### PR TITLE
fixed error with sin and cos in k-space force computation

### DIFF
--- a/core/example/longrange/ewald.cpp
+++ b/core/example/longrange/ewald.cpp
@@ -221,7 +221,7 @@ double TEwald::compute( ParticleList &particles, double lx, double ly,
                     Kokkos::atomic_add( &U_trigonometric( 2 * kidx ),
                                         q( idx ) * cos( kr ) );
                     Kokkos::atomic_add( &U_trigonometric( 2 * kidx + 1 ),
-                                        q( idx ) * cos( kr ) );
+                                        q( idx ) * sin( kr ) );
                 }
             }
         }


### PR DESCRIPTION
Fixes an error in the computation of the forces in the k-space part of the Ewald solver.